### PR TITLE
Fix whiteboard sizing, add draggable divider, course picture, course title

### DIFF
--- a/app/components/WhiteboardCanvas.tsx
+++ b/app/components/WhiteboardCanvas.tsx
@@ -36,13 +36,14 @@ const PRESET_COLORS = [
 
 // Stroke data emitted via onStroke — matches backend WhiteboardDrawingMessage shape
 export interface StrokeEvent {
-  action: "draw" | "clear";
+  action: "draw" | "clear" | "snapshot";
   x?: number;
   y?: number;
   previousX?: number;
   previousY?: number;
   color?: string;
   size?: number;
+  dataURL?: string;
 }
 
 // Imperative handle that parent can use to inject remote strokes (for read-only student view)
@@ -160,6 +161,16 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
     setTextElements(entry.textElements);
   }, []);
 
+  const broadcastSnapshot = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas || !onStroke) return;
+    // Wait a tick so the canvas is fully redrawn before we snapshot it
+    setTimeout(() => {
+      const dataURL = canvas.toDataURL();
+      onStroke({ action: "snapshot", dataURL });
+    }, 30);
+  }, [onStroke]);
+
   const undo = useCallback(() => {
     if (historyIdxRef.current <= 0) return;
     setEditingId(null);
@@ -167,7 +178,8 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
     historyIdxRef.current--;
     applyEntry(historyRef.current[historyIdxRef.current]);
     setHistState({ idx: historyIdxRef.current, len: historyRef.current.length });
-  }, [applyEntry]);
+    broadcastSnapshot();
+  }, [applyEntry, broadcastSnapshot]);
 
   const redo = useCallback(() => {
     if (historyIdxRef.current >= historyRef.current.length - 1) return;
@@ -176,7 +188,8 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
     historyIdxRef.current++;
     applyEntry(historyRef.current[historyIdxRef.current]);
     setHistState({ idx: historyIdxRef.current, len: historyRef.current.length });
-  }, [applyEntry]);
+    broadcastSnapshot();
+  }, [applyEntry, broadcastSnapshot]);
 
   // ── Keyboard shortcuts ─────────────────────────────────────────────────────
   useEffect(() => {
@@ -194,38 +207,27 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
   // ── Canvas init with DPR fix ───────────────────────────────────────────────
   useEffect(() => {
     const canvas = canvasRef.current;
-    const container = containerRef.current;
-    if (!canvas || !container) return;
+    if (!canvas) return;
 
-    const initCanvas = (preserve: boolean) => {
-      const dpr = window.devicePixelRatio || 1;
-      const rect = container.getBoundingClientRect();
-      const ctx = canvas.getContext("2d");
-      if (!ctx) return;
-      let snapshot: string | null = null;
-      const prevW = canvas.width;
-      const prevH = canvas.height;
-      if (preserve && prevW > 0 && prevH > 0) snapshot = canvas.toDataURL();
-      canvas.width = Math.round(rect.width * dpr);
-      canvas.height = Math.round(rect.height * dpr);
-      canvas.style.width = `${rect.width}px`;
-      canvas.style.height = `${rect.height}px`;
-      dprRef.current = dpr;
-      ctx.scale(dpr, dpr);
-      ctx.fillStyle = "#FFFFFF";
-      ctx.fillRect(0, 0, rect.width, rect.height);
-      if (snapshot) {
-        const img = new Image();
-        img.onload = () => ctx.drawImage(img, 0, 0, prevW / dpr, prevH / dpr);
-        img.src = snapshot;
-      }
-    };
+    // Fixed logical canvas size — identical coordinate system for teacher and student.
+    // Users with smaller windows scroll; resizing does NOT clear content.
+    const LOGICAL_WIDTH = 2400;
+    const LOGICAL_HEIGHT = 1600;
 
-    initCanvas(false);
+    const dpr = window.devicePixelRatio || 1;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    canvas.width = Math.round(LOGICAL_WIDTH * dpr);
+    canvas.height = Math.round(LOGICAL_HEIGHT * dpr);
+    canvas.style.width = `${LOGICAL_WIDTH}px`;
+    canvas.style.height = `${LOGICAL_HEIGHT}px`;
+    dprRef.current = dpr;
+    ctx.scale(dpr, dpr);
+    ctx.fillStyle = "#FFFFFF";
+    ctx.fillRect(0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT);
+
     setTimeout(() => takeSnapshot(), 0);
-    const onResize = () => initCanvas(true);
-    window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
   }, [takeSnapshot]);
 
   // ── Selection helpers ──────────────────────────────────────────────────────
@@ -338,17 +340,31 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
     if (onStroke) onStroke({ action: "clear" });
   }, [takeSnapshot, onStroke]);
 
-  // Expose method for parent to inject remote strokes (used for live-share student view)
   useImperativeHandle(ref, () => ({
     applyRemoteStroke: (stroke: StrokeEvent) => {
       const ctx = canvasRef.current?.getContext("2d");
       if (!ctx || !canvasRef.current) return;
+      const cssW = canvasRef.current.width / dprRef.current;
+      const cssH = canvasRef.current.height / dprRef.current;
+
       if (stroke.action === "clear") {
         ctx.fillStyle = "#FFFFFF";
-        ctx.fillRect(0, 0, canvasRef.current.width / dprRef.current, canvasRef.current.height / dprRef.current);
+        ctx.fillRect(0, 0, cssW, cssH);
+        return;
+      }
+      // Replace full canvas from snapshot (used for undo/redo sync)
+      if (stroke.action === "snapshot" && stroke.dataURL) {
+        const img = new Image();
+        img.onload = () => {
+          ctx.fillStyle = "#FFFFFF";
+          ctx.fillRect(0, 0, cssW, cssH);
+          ctx.drawImage(img, 0, 0, cssW, cssH);
+        };
+        img.src = stroke.dataURL;
         return;
       }
       if (stroke.action === "draw" && stroke.previousX != null && stroke.previousY != null && stroke.x != null && stroke.y != null) {
+
         ctx.beginPath();
         ctx.moveTo(stroke.previousX, stroke.previousY);
         ctx.lineTo(stroke.x, stroke.y);
@@ -647,11 +663,9 @@ const WhiteboardCanvas = forwardRef<WhiteboardCanvasHandle, WhiteboardCanvasProp
       )}
 
       {/* ── Canvas area ── */}
-      <div ref={containerRef} style={{ flex: 1, overflow: "hidden", position: "relative" }}>
-        <canvas
+      <div ref={containerRef} style={{ flex: 1, overflow: "auto", position: "relative", background: "#F3F4F6" }}>        <canvas
           ref={canvasRef}
-          style={{ display: "block", width: "100%", height: "100%", cursor: readOnly ? "default" : cursor, touchAction: "none", background: "#FFFFFF", border: "1px solid #D1D5DB" }}
-          onMouseDown={readOnly ? undefined : startDrawing}
+          style={{ display: "block", cursor: readOnly ? "default" : cursor, touchAction: "none", background: "#FFFFFF", border: "1px solid #D1D5DB" }}          onMouseDown={readOnly ? undefined : startDrawing}
           onMouseMove={readOnly ? undefined : draw}
           onMouseUp={readOnly ? undefined : stopDrawing}
           onMouseLeave={readOnly ? undefined : stopDrawing}

--- a/app/session/[courseId]/page.tsx
+++ b/app/session/[courseId]/page.tsx
@@ -26,8 +26,8 @@ function SessionPageInner() {
   const params = useParams();
   const courseId = params.courseId as string;
   const searchParams = useSearchParams();
-  const sessionId = searchParams.get("sessionId"); // sessionId aus URL (?sessionId=...)
-  const { user, isLoading } = useUser();
+  const sessionId = searchParams.get("sessionId");
+  const sessionTitle = searchParams.get("title") ?? `Session #${sessionId ?? ""}`;  const { user, isLoading } = useUser();
   const apiService = useApi();
   const [chatOpen, setChatOpen] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
@@ -41,6 +41,34 @@ function SessionPageInner() {
   const chatBottomRef = useRef<HTMLDivElement | null>(null);
   // Teacher's userId – fetched from GET /courses/{courseId} (no auth required)
   const [teacherUserId, setTeacherUserId] = useState<number | undefined>(undefined);
+
+    // Split ratio between teacher's whiteboard (left) and personal whiteboard (right)
+    const [splitRatio, setSplitRatio] = useState(0.5);
+    const splitContainerRef = useRef<HTMLDivElement | null>(null);
+    const isDraggingSplit = useRef(false);
+    const [dividerHover, setDividerHover] = useState(false);
+
+    // Listen for mouse movements globally while dragging the divider
+    useEffect(() => {
+        const onMouseMove = (e: MouseEvent) => {
+            if (!isDraggingSplit.current || !splitContainerRef.current) return;
+            const rect = splitContainerRef.current.getBoundingClientRect();
+            const ratio = (e.clientX - rect.left) / rect.width;
+            // Clamp between 10% and 90% so neither side collapses entirely
+            setSplitRatio(Math.min(0.9, Math.max(0.1, ratio)));
+        };
+        const onMouseUp = () => {
+            isDraggingSplit.current = false;
+            document.body.style.cursor = "";
+            document.body.style.userSelect = "";
+        };
+        window.addEventListener("mousemove", onMouseMove);
+        window.addEventListener("mouseup", onMouseUp);
+        return () => {
+            window.removeEventListener("mousemove", onMouseMove);
+            window.removeEventListener("mouseup", onMouseUp);
+        };
+    }, []);
 
   // Auth guard: only logged-in users allowed
   useEffect(() => {
@@ -179,10 +207,10 @@ function SessionPageInner() {
           >
             <ArrowLeft size={14} /> Leave Session
           </button>
-          <div style={{ fontSize: "15px", fontWeight: 600, color: "#1A1A2E" }}>
-            Course Session #{courseId}
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
+            <div style={{ fontSize: "15px", fontWeight: 600, color: "#1A1A2E" }}>
+                {sessionTitle}
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
             <span style={{ fontSize: "12px", color: "#9CA3AF" }}>Live</span>
             <button
               onClick={() => setChatOpen(true)}
@@ -376,7 +404,7 @@ function SessionPageInner() {
           <ArrowLeft size={14} /> Leave Session
         </button>
         <div style={{ fontSize: "15px", fontWeight: 600, color: "#1A1A2E" }}>
-          Course Session #{courseId}
+          {sessionTitle}
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: "12px" }}>
           <span style={{ fontSize: "12px", color: "#9CA3AF" }}>Live</span>
@@ -401,37 +429,83 @@ function SessionPageInner() {
         </div>
       </div>
 
-      {/* ── Split view: teacher (left) + student (right) ── */}
-      <div style={{
-        display: "flex",
-        flex: 1,
-        overflow: "hidden",
-        gap: "16px",
-        padding: "16px",
-        background: "rgba(0,0,0,0.03)",
-      }}>
-        {/* Left: teacher's whiteboard (read-only) */}
-        <div style={{
-          flex: 1,
-          overflow: "hidden",
-          borderRadius: "12px",
-          boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
-          background: "white",
-        }}>
-         <WhiteboardCanvas ref={teacherBoardRef} readOnly fullHeight={false} label="Teacher's Whiteboard" />
-        </div>
+        {/* ── Split view: teacher (left) + student (right) with draggable divider ── */}
+        <div
+            ref={splitContainerRef}
+            style={{
+                display: "flex",
+                flex: 1,
+                overflow: "hidden",
+                padding: "16px",
+                background: "rgba(0,0,0,0.03)",
+            }}
+        >
+            {/* Left: teacher's whiteboard (read-only) */}
+            <div style={{
+                flex: splitRatio,
+                minWidth: 0,
+                overflow: "hidden",
+                borderRadius: "12px",
+                boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
+                background: "white",
+            }}>
+                <WhiteboardCanvas ref={teacherBoardRef} readOnly fullHeight={false} label="Teacher's Whiteboard" />
+            </div>
 
-        {/* Right: student's personal whiteboard (editable) */}
-        <div style={{
-          flex: 1,
-          overflow: "hidden",
-          borderRadius: "12px",
-          boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
-          background: "white",
-        }}>
-          <WhiteboardCanvas fullHeight={false} label="Your Personal Notes" />
+            {/* Draggable divider with thin line + rhombus indicator */}
+            <div
+                onMouseDown={() => {
+                    isDraggingSplit.current = true;
+                    document.body.style.cursor = "col-resize";
+                    document.body.style.userSelect = "none";
+                }}
+                onMouseEnter={() => setDividerHover(true)}
+                onMouseLeave={() => setDividerHover(false)}
+                style={{
+                    width: "20px",
+                    cursor: "col-resize",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    flexShrink: 0,
+                    position: "relative",
+                }}
+                title="Drag to resize"
+            >
+                {/* Thin vertical line running the full height */}
+                <div style={{
+                    width: "1px",
+                    height: "100%",
+                    background: "rgba(91,108,255,0.3)",
+                }} />
+                {/* Rhombus (diamond) outline, fills on hover */}
+                <div style={{
+                    position: "absolute",
+                    top: "50%",
+                    left: "50%",
+                    transform: "translate(-50%, -50%) rotate(45deg)",
+                    width: "12px",
+                    height: "12px",
+                    background: dividerHover ? "#5B6CFF" : "transparent",
+                    border: "2px solid #5B6CFF",
+                    borderRadius: "2px",
+                    boxShadow: dividerHover ? "0 2px 6px rgba(91,108,255,0.35)" : "none",
+                    transition: "background 0.15s, box-shadow 0.15s",
+                }} />
+            </div>
+
+            {/* Right: student's personal whiteboard (editable) */}
+            <div style={{
+                flex: 1 - splitRatio,
+                minWidth: 0,
+                overflow: "hidden",
+                borderRadius: "12px",
+                boxShadow: "0 4px 16px rgba(0,0,0,0.08)",
+                background: "white",
+            }}>
+                <WhiteboardCanvas fullHeight={false} label="Your Personal Notes" />
+            </div>
         </div>
-      </div>
 
       {/* ── Chat overlay backdrop ── */}
       {chatOpen && (

--- a/app/student-dashboard/[id]/page.tsx
+++ b/app/student-dashboard/[id]/page.tsx
@@ -13,7 +13,8 @@ interface Course {
     description: string;
     courseCode: string;
     teacher: string;
-    }
+    pictureURL?: string;
+}
 
 // Response shape from backend GET /users/{id}/courses (CourseGetDTO)
 interface CourseGetDTO {
@@ -101,12 +102,13 @@ interface CourseGetDTO {
     (async () => {
       try {
           const data = await apiService.get<CourseGetDTO[]>(`/users/${user.id}/courses`, user.token ?? undefined);        setCourses(data.map((c) => ({
-          courseId: c.id,
-          title: c.title,
-          description: c.description ?? "",
-          courseCode: c.courseCode,
-          teacher: "", // teacher name not included in DTO yet
-        })));
+              courseId: c.id,
+              title: c.title,
+              description: c.description ?? "",
+              courseCode: c.courseCode,
+              teacher: "",
+              pictureURL: c.pictureURL,
+          })));
       } catch (err) {
         if (err instanceof Error) {
           console.error("Failed to load enrolled courses:", err.message);
@@ -161,20 +163,22 @@ interface CourseGetDTO {
           {courses.map(course => (
             <Card key={course.courseId} style={{ width: 280, cursor: "pointer" }} onClick={() => router.push(`/users/${urlId}/courses/${course.courseId}`)}> {/* später user.id wenn id korrekt aus backend gelesen wird */}
               {/* Course Image */}
-              <div style={{
-                background: gradients[course.courseId % gradients.length],
-                borderRadius: "8px",
-                height: "80px",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                fontSize: "24px",
-                fontWeight: 700,
-                color: "white",
-                marginBottom: "12px"
-              }}>
-                {course.title.split(" ").map(word => word[0]).join("").toUpperCase()}
-              </div>
+                <div style={{
+                    background: course.pictureURL
+                        ? `linear-gradient(rgba(0,0,0,0.4), rgba(0,0,0,0.4)), url(${course.pictureURL}) center/cover`
+                        : gradients[course.courseId % gradients.length],
+                    borderRadius: "8px",
+                    height: "80px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    fontSize: "24px",
+                    fontWeight: 700,
+                    color: "white",
+                    marginBottom: "12px"
+                }}>
+                    {course.title.split(" ").map(word => word[0]).join("").toUpperCase()}
+                </div>
               {/* Course Info */}
               <h3 style={{ margin: 0 }}>{course.title}</h3>
               <p style={{ color: "var(--text-secondary)", margin: "4px 0" }}>{course.description}</p>

--- a/app/users/[id]/courses/[courseId]/page.tsx
+++ b/app/users/[id]/courses/[courseId]/page.tsx
@@ -34,6 +34,7 @@ export default function CoursePage() {
   const [starting, setStarting] = useState(false);
   const [createModalOpen, setCreateModalOpen] = useState(false);
   const [newSessionTitle, setNewSessionTitle] = useState("");
+  const [courseTitle, setCourseTitle] = useState<string>("");
 
   useEffect(() => {
     const token = localStorage.getItem("token");
@@ -41,6 +42,13 @@ export default function CoursePage() {
       router.push("/login");
       return;
     }
+    // Fetch course info (title, etc.)
+    (async () => {
+      try {
+        const course = await apiService.get<{ title: string }>(`/courses/${courseId}`);
+        setCourseTitle(course.title);
+      } catch { /* non-critical */ }
+    })();
     // Fetch sessions for this course from backend
     (async () => {
       try {
@@ -64,7 +72,9 @@ export default function CoursePage() {
   const isTeacher = user?.role === "TEACHER";
 
   const handleJoinSession = (sessionId: number) => {
-    router.push(`/session/${courseId}?sessionId=${sessionId}`);
+    const session = sessions.find(s => s.id === sessionId);
+    const title = encodeURIComponent(session?.title ?? `Session #${sessionId}`);
+    router.push(`/session/${courseId}?sessionId=${sessionId}&title=${title}`);
   };
 
   // Opens modal to name the new session
@@ -101,8 +111,7 @@ export default function CoursePage() {
         ...prev,
       ]);
       setCreateModalOpen(false);
-      router.push(`/session/${courseId}?sessionId=${created.sessionId}`);
-    } catch (err) {
+      router.push(`/session/${courseId}?sessionId=${created.sessionId}&title=${encodeURIComponent(title)}`);    } catch (err) {
       if (err instanceof Error) {
         message.error(`Failed to start session: ${err.message}`);
       }
@@ -157,7 +166,7 @@ export default function CoursePage() {
         <div style={{ marginBottom: "12px" }}>
           <h2 style={{ margin: 0, color: "#1A1A2E" }}>Sessions</h2>
           <p style={{ margin: "2px 0 0 0", color: "#6B7280", fontSize: "13px" }}>
-            Course #{courseId} — {isTeacher ? "Manage your sessions" : "Join live sessions and view recordings"}
+            {courseTitle || `Course #${courseId}`} — {isTeacher ? "Manage your sessions" : "Join live sessions and view recordings"}
           </p>
         </div>
 


### PR DESCRIPTION
final bug fixes and essential UI changes:

**Whiteboard sizing (WhiteboardCanvas.tsx)**

- Fixed logical canvas size (2400×1600) instead of fitting container
- Container is now scrollable 
- Resizing window no longer deletes drawings
- Teacher and student share the same coordinate system

**Draggable split-view divider (session/[courseId]/page.tsx)**

- Thin vertical line between the two whiteboards
- Rhombus indicator 
- Drag to resize 

**Course pictures visible for students (student-dashboard/[id]/page.tsx)**

- Added pictureURL to Course interface + mapping + card background
- Students now see the same course image the teacher uploaded

**Real session title in session header (session/[courseId]/page.tsx + users/[id]/courses/[courseId]/page.tsx)**

- Session name passed via URL query param (?title=...) when joining/creating
- Header displays actual session name
- Fixed for both teacher view and student view

**Real course title on course page (users/[id]/courses/[courseId]/page.tsx)**

- Fetches course details via GET /courses/{courseId}
- Shows actual course title 